### PR TITLE
fix(docker-compose, frontend): separate API_URL environment into PUBLIC_ and PRIVATE_

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,10 @@ services:
       - .:/app
       - node_modules:/app/frontend/node_modules
     environment:
-      API_URL: http://localhost:5000/graphql
+      PRIVATE_API_URL: http://rails:3000/graphql
+      PUBLIC_API_URL: http://localhost:5000/graphql
+    depends_on:
+      - rails
     ports:
       - '3000:3000'
   gql_gen:

--- a/frontend/lib/initApollo.ts
+++ b/frontend/lib/initApollo.ts
@@ -46,7 +46,7 @@ const create = (initialState?: NormalizedCacheObject) => {
   const cache = new InMemoryCache().restore(initialState || {})
 
   const httpLink = new HttpLink({
-    uri: process.env.API_URL,
+    uri: isBrowser ? process.env.PUBLIC_API_URL : process.env.PRIVATE_API_URL,
     credentials: 'same-origin',
   })
 


### PR DESCRIPTION
fix #86 